### PR TITLE
Gracefully shutdown

### DIFF
--- a/redshiftsink/cmd/redshiftbatcher/main.go
+++ b/redshiftsink/cmd/redshiftbatcher/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"time"
 
 	"flag"
 	"github.com/spf13/cobra"
@@ -71,6 +72,13 @@ func run(cmd *cobra.Command, args []string) {
 		klog.Info("Sigterm signal received")
 	}
 	cancel()
+
+	// TODO: the processing batching function should signal back
+	// It does not at present
+	// https://github.com/practo/tipoca-stream/issues/18
+	klog.Info("Waiting the batcher processees to gracefully shutdown")
+	time.Sleep(5 * time.Second)
+
 	wg.Wait()
 	if err = consumerGroup.Close(); err != nil {
 		klog.Errorf("Error closing group: %v", err)

--- a/redshiftsink/pkg/consumer/consumer.go
+++ b/redshiftsink/pkg/consumer/consumer.go
@@ -23,7 +23,7 @@ type consumer struct {
 // Setup is run at the beginning of a new session, before ConsumeClaim
 func (c consumer) Setup(sarama.ConsumerGroupSession) error {
 	// Mark the consumer as ready
-	klog.V(4).Info("Setting up consumer")
+	klog.V(3).Info("Setting up consumer")
 	close(c.ready)
 	return nil
 }
@@ -31,7 +31,7 @@ func (c consumer) Setup(sarama.ConsumerGroupSession) error {
 // Cleanup is run at the end of a session,
 // once all ConsumeClaim goroutines have exited
 func (c consumer) Cleanup(sarama.ConsumerGroupSession) error {
-	klog.V(4).Info("Cleaning up consumer")
+	klog.V(3).Info("Cleaning up consumer")
 	return nil
 }
 
@@ -67,6 +67,9 @@ func (c consumer) processMessage(
 		klog.Info("Graceful shutdown requested, not inserting in batch")
 		return nil
 	default:
+		// klog.V(99).Infof(
+		// 	"Inserted message: items=%d\n", b.mbatch.TotalItems(),
+		// )
 		b.mbatch.Insert(message)
 	}
 

--- a/redshiftsink/pkg/consumer/consumer_group.go
+++ b/redshiftsink/pkg/consumer/consumer_group.go
@@ -146,6 +146,6 @@ func (c *saramaConsumerGroup) Close() error {
 		return err
 	}
 
-	klog.Info("Shutdown completed.")
+	klog.Info("Closed open connections.")
 	return nil
 }

--- a/redshiftsink/pkg/consumer/manager.go
+++ b/redshiftsink/pkg/consumer/manager.go
@@ -101,7 +101,7 @@ func (c *Manager) printLastOffsets() {
 			continue
 		}
 		klog.Infof(
-			"topic:%s, partition: 0, lastOffset: %d\n",
+			"topic:%s, partition:0, lastOffset:%d (kafka lastoffset)\n",
 			topic,
 			lastOffset,
 		)
@@ -123,15 +123,16 @@ func (c *Manager) Consume(ctx context.Context, wg *sync.WaitGroup) {
 
 		c.printLastOffsets()
 
-		klog.V(4).Infof("Manager.Consume for %d topic(s)\n", len(topics))
+		klog.V(2).Infof("Manager.Consume for %d topic(s)\n", len(topics))
 		err := c.consumerGroup.Consume(ctx, topics, c.Ready)
 		if err != nil {
 			klog.Fatalf("Error from consumer: %v", err)
 		}
 		// check if context was cancelled, the consumer should stop
 		if ctx.Err() != nil {
+			klog.V(2).Info("Manager.Context cancelled")
 			return
 		}
-		klog.V(4).Info("Manager.Consume completed loop, will re run")
+		klog.V(2).Info("Manager.Consume completed loop, will re run")
 	}
 }


### PR DESCRIPTION
All routines should begin from where it last left off and should shutdown gracefully. We need the consumers to be really accurate on this. 

Even though the system is idempotent let's make the consumers rock solid.  

More Info: https://github.com/Shopify/sarama/issues/1776

TODO:
- If the batching library also handles context based signals it can prevent earlier shutdown and few more calls (many of the lage is huge) https://github.com/herryg91/gobatch/issues/2  