### PR TITLE
Reduce schema registry calls in batcher msg add

### DIFF
--- a/redshiftsink/pkg/kafka/producer.go
+++ b/redshiftsink/pkg/kafka/producer.go
@@ -69,7 +69,7 @@ func (c *AvroProducer) CreateSchema(
 		c.registry, topic, false, 2,
 	)
 	if schema == nil || schema.Schema() != schemeStr {
-		klog.V(2).Infof("Creating schema version. topic: %s", topic)
+		klog.V(2).Infof("%s: Creating schema for the topic", topic)
 		schema, err = c.registry.CreateSchema(
 			topic, scheme, schemaregistry.Avro, false,
 		)
@@ -82,14 +82,13 @@ func (c *AvroProducer) CreateSchema(
 	return schema.ID(), created, nil
 }
 
-func (c *AvroProducer) Add(topic string, schema string,
-	key []byte, value map[string]interface{}) error {
-
-	schemaId, _, err := c.CreateSchema(topic, schema)
-	if err != nil {
-		return err
-	}
-
+func (c *AvroProducer) Add(
+	topic string,
+	schema string,
+	schemaID int,
+	key []byte,
+	value map[string]interface{},
+) error {
 	avroCodec, err := goavro.NewCodec(schema)
 	if err != nil {
 		return err
@@ -101,7 +100,7 @@ func (c *AvroProducer) Add(topic string, schema string,
 	}
 
 	binaryMsg := &AvroEncoder{
-		SchemaID: schemaId,
+		SchemaID: schemaID,
 		Content:  binaryValue,
 	}
 

--- a/redshiftsink/pkg/redshiftbatcher/batcher_handler.go
+++ b/redshiftsink/pkg/redshiftbatcher/batcher_handler.go
@@ -151,7 +151,7 @@ func (h *batcherHandler) ConsumeClaim(
 	var lastSchemaId *int
 	processChan := make(chan []*serializer.Message, *h.maxConcurrency)
 	errChan := make(chan error)
-	processor := newBatchProcessor(
+	processor, err := newBatchProcessor(
 		h.consumerGroupID,
 		claim.Topic(),
 		claim.Partition(),
@@ -162,6 +162,15 @@ func (h *batcherHandler) ConsumeClaim(
 		h.kafkaLoaderTopicPrefix,
 		*h.maxConcurrency,
 	)
+	if err != nil {
+		klog.Errorf(
+			"Error making the batch processor for topic: %v, err: %v",
+			claim.Topic(),
+			err,
+		)
+		return err
+	}
+
 	maxBufSize := h.maxSize
 	if h.maxBytesPerBatch != nil {
 		maxBufSize = serializer.DefaultMessageBufferSize


### PR DESCRIPTION
Decouple schema creation and message addition in Kafka
This will reduce schema registry calls

Fixes https://github.com/practo/tipoca-stream/issues/182
Hides https://github.com/practo/tipoca-stream/issues/187