### PR TITLE
Divide into chunks

### DIFF
--- a/redshiftsink/controllers/sinkgroup_controller.go
+++ b/redshiftsink/controllers/sinkgroup_controller.go
@@ -153,13 +153,8 @@ func (sb *buildSinkGroup) buildBatchers(
 			sb.sgType,
 			defaultImage,
 		)
-		units := []deploymentUnit{
-			deploymentUnit{
-				id:            "",
-				sinkGroupSpec: sinkGroupSpec,
-				topics:        sb.topics,
-			},
-		}
+		units := []deploymentUnit{}
+		// ReloadingSinkGroup
 		if len(sb.topics) > 0 && sb.calc != nil { // overwrite units if currently reloading and calculation is available
 			if len(sb.calc.batchersRealtime) > 0 {
 				mainSinkGroupSpec = applyBatcherSinkGroupDefaults(
@@ -180,7 +175,10 @@ func (sb *buildSinkGroup) buildBatchers(
 			)
 			allocator.allocateReloadingUnits()
 			units = allocator.units
+		} else { // MainSinkGroup or ReloadDupeSinkGroup
+			units = allocateUnitWithChunks(sb.topics, sinkGroupSpec, 100)
 		}
+
 		for _, unit := range units {
 			consumerGroups, err := computeConsumerGroups(
 				sb.topicGroups, unit.topics)
@@ -250,13 +248,8 @@ func (sb *buildSinkGroup) buildLoaders(
 			sb.sgType,
 			defaultImage,
 		)
-		units := []deploymentUnit{
-			deploymentUnit{
-				id:            "",
-				sinkGroupSpec: sinkGroupSpec,
-				topics:        sb.topics,
-			},
-		}
+		units := []deploymentUnit{}
+		// ReloadingSinkGroup
 		if len(sb.topics) > 0 && sb.calc != nil { // overwrite units if currently reloading and calculation is available
 			if len(sb.calc.loadersRealtime) > 0 {
 				mainSinkGroupSpec = applyLoaderSinkGroupDefaults(
@@ -284,6 +277,8 @@ func (sb *buildSinkGroup) buildLoaders(
 					topics:        makeBatcherTopics(unit.topics),
 				})
 			}
+		} else { // MainSinkGroup or ReloadDupeSinkGroup
+			units = allocateUnitWithChunks(sb.topics, sinkGroupSpec, 100)
 		}
 
 		for _, unit := range units {

--- a/redshiftsink/controllers/unit_allocator_test.go
+++ b/redshiftsink/controllers/unit_allocator_test.go
@@ -5,6 +5,63 @@ import (
 	"testing"
 )
 
+func TestAllocateUnitChunks(t *testing.T) {
+	t.Parallel()
+	//go test -v ./controllers/... -run ^TestAllocateUnitChunks
+
+	tests := []struct {
+		name      string
+		topics    []string
+		chunkSize int
+		units     []deploymentUnit
+	}{
+		{
+			name:      "singleChunk",
+			topics:    []string{"db.inventory.t1", "db.inventory.t2", "db.inventory.t3", "db.inventory.t4"},
+			chunkSize: 100,
+			units: []deploymentUnit{
+				deploymentUnit{
+					id:     "0",
+					topics: []string{"db.inventory.t1", "db.inventory.t2", "db.inventory.t3", "db.inventory.t4"},
+				},
+			},
+		},
+		{
+			name:      "multiChunk",
+			topics:    []string{"t1", "t2", "t3", "t4", "t5", "t6", "t7", "t8", "t9", "t10"},
+			chunkSize: 3,
+			units: []deploymentUnit{
+				deploymentUnit{
+					id:     "0",
+					topics: []string{"t1", "t2", "t3"},
+				},
+				deploymentUnit{
+					id:     "1",
+					topics: []string{"t4", "t5", "t6"},
+				},
+				deploymentUnit{
+					id:     "2",
+					topics: []string{"t7", "t8", "t9"},
+				},
+				deploymentUnit{
+					id:     "3",
+					topics: []string{"t10"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gotUnits := allocateUnitWithChunks(tc.topics, nil, tc.chunkSize)
+			if !reflect.DeepEqual(gotUnits, tc.units) {
+				t.Errorf("\nexpected (%v): %+v\ngot (%v): %+v\n", len(tc.units), tc.units, len(gotUnits), gotUnits)
+			}
+		})
+	}
+}
+
 func TestAllocateReloadingUnits(t *testing.T) {
 	t.Parallel()
 

--- a/redshiftsink/controllers/util.go
+++ b/redshiftsink/controllers/util.go
@@ -141,6 +141,10 @@ func getHashStructure(v interface{}) (string, error) {
 	return hash[:6], nil
 }
 
+func toStrPtr(s string) *string {
+	return &s
+}
+
 func toIntPtr(i int) *int {
 	return &i
 }


### PR DESCRIPTION
**Why?**
This is required as the configMap size restriction. It does not allow more than X bytes. 
So splitting pods into multiple pods after 100 topics.


Long term should be to change the config structure of batcher and loader to allow as many topics with common config. Config is repeated to allow all scenario possible at present - any kafka cluster, any combination of consumer groups. Such things are good but not really needed. https://github.com/practo/tipoca-stream/issues/203