### PR TITLE
Allow only few resources to make testing be possible in prod

### DIFF
--- a/redshiftsink/cmd/redshiftsink/main.go
+++ b/redshiftsink/cmd/redshiftsink/main.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/practo/klog/v2"
+	prometheus "github.com/practo/tipoca-stream/redshiftsink/pkg/prometheus"
 	pflag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -54,7 +55,7 @@ func main() {
 	rand.Seed(time.Now().UnixNano())
 
 	var enableLeaderElection bool
-	var batcherImage, loaderImage, secretRefName, secretRefNamespace, kafkaVersion, metricsAddr, allowedRsks string
+	var batcherImage, loaderImage, secretRefName, secretRefNamespace, kafkaVersion, metricsAddr, allowedRsks, prometheusURL string
 	var redshiftMaxOpenConns, redshiftMaxIdleConns int
 	flag.StringVar(&batcherImage, "default-batcher-image", "746161288457.dkr.ecr.ap-south-1.amazonaws.com/redshiftbatcher:latest", "image to use for the redshiftbatcher")
 	flag.StringVar(&loaderImage, "default-loader-image", "746161288457.dkr.ecr.ap-south-1.amazonaws.com/redshiftloader:latest", "image to use for the redshiftloader")
@@ -65,7 +66,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false, "Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.IntVar(&redshiftMaxOpenConns, "default-redshift-max-open-conns", 10, "the maximum number of open connections allowed to redshift per redshiftsink resource")
 	flag.IntVar(&redshiftMaxIdleConns, "default-redshift-max-idle-conns", 2, "the maximum number of idle connections allowed to redshift per redshiftsink resource")
-	flags.StringVar(&allowedRsks, "allowed-rsks", "", "comma separated list of names of rsk resources to allow, if empty all rsk resources are allowed")
+	flag.StringVar(&allowedRsks, "allowed-rsks", "", "comma separated list of names of rsk resources to allow, if empty all rsk resources are allowed")
+	flag.StringVar(&prometheusURL, "prometheus-url", "", "optional, giving prometheus makes the operator enable new features using time series data. Features: loader throttling, resetting offsets of 0 throughput topics.")
 	flag.Parse()
 
 	ctrl.SetLogger(klogr.New())
@@ -90,6 +92,14 @@ func main() {
 		setupLog.Error(err, "unable to make uncached client")
 		os.Exit(1)
 	}
+	var prometheusClient prometheus.Client
+	if prometheusURL != "" {
+		prometheusClient, err = prometheus.NewClient(prometheusURL)
+		if err != nil {
+			setupLog.Error(err, "unable to init prometheus")
+			os.Exit(1)
+		}
+	}
 
 	if err = (&controllers.RedshiftSinkReconciler{
 		Client:                      uncachedClient,
@@ -111,6 +121,7 @@ func main() {
 		DefaultRedshiftMaxOpenConns: redshiftMaxOpenConns,
 		DefaultRedshiftMaxIdleConns: redshiftMaxIdleConns,
 		AllowedResources:            strings.Split(allowedRsks, ","),
+		PrometheusClient:            prometheusClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedshiftSink")
 		os.Exit(1)

--- a/redshiftsink/config/operator/kustomization_sample.yaml
+++ b/redshiftsink/config/operator/kustomization_sample.yaml
@@ -19,7 +19,6 @@ secretGenerator:
   - s3AccessKeyId=sample-access-key-id
   - s3SecretAccessKey=sample-secret-access-key
   - schemaRegistryURL=sample-reg-url
-  - prometheusURL=sample-optional-prometheus-url
   - tlsEnable=true
   - tlsUserCert=base64Encodedsample
   - tlsUserKey=base64Encodedsample

--- a/redshiftsink/config/operator/redshiftsink_operator.yaml
+++ b/redshiftsink/config/operator/redshiftsink_operator.yaml
@@ -48,6 +48,8 @@ spec:
        - --default-loader-image=746161288457.dkr.ecr.ap-south-1.amazonaws.com/redshiftloader:latest
        - --default-redshift-max-open-conns=10
        - --default-redshift-max-idle-conns=2
+       - --allowed-rsks=
+       - --promethus-url=
        resources:
          limits:
            cpu: 300m

--- a/redshiftsink/controllers/loader_deployment.go
+++ b/redshiftsink/controllers/loader_deployment.go
@@ -140,7 +140,6 @@ func loaderSecret(secret map[string]string) (map[string]string, error) {
 		"s3AccessKeyId",
 		"s3SecretAccessKey",
 		"schemaRegistryURL",
-		"prometheusURL",
 		"redshiftHost",
 		"redshiftPort",
 		"redshiftDatabase",
@@ -204,6 +203,7 @@ func NewLoader(
 	tlsConfig *kafka.TLSConfig,
 	defaultMaxOpenConns int,
 	defaultMaxIdleConns int,
+	prometheusURL string,
 ) (
 	Deployment,
 	error,
@@ -299,7 +299,7 @@ func NewLoader(
 			BucketDir:       secret["s3LoaderBucketDir"],
 		},
 		SchemaRegistryURL: secret["schemaRegistryURL"],
-		PrometheusURL:     secret["prometheusURL"],
+		PrometheusURL:     prometheusURL,
 		Redshift: redshift.RedshiftConfig{
 			Schema:       rsk.Spec.Loader.RedshiftSchema,
 			TableSuffix:  tableSuffix,

--- a/redshiftsink/controllers/sinkgroup_controller.go
+++ b/redshiftsink/controllers/sinkgroup_controller.go
@@ -69,7 +69,7 @@ type sinkGroupBuilder interface {
 	setRealtimeCalculator(calc *realtimeCalculator) sinkGroupBuilder
 
 	buildBatchers(secret map[string]string, defaultImage, defaultKafkaVersion string, tlsConfig *kafka.TLSConfig) sinkGroupBuilder
-	buildLoaders(secret map[string]string, defaultImage, tableSuffix string, defaultKafkaVersion string, tlsConfig *kafka.TLSConfig, defaultMaxOpenConns int, defaultMaxIdleConns int) sinkGroupBuilder
+	buildLoaders(secret map[string]string, defaultImage, tableSuffix string, defaultKafkaVersion string, tlsConfig *kafka.TLSConfig, defaultMaxOpenConns int, defaultMaxIdleConns int, prometheusURL string) sinkGroupBuilder
 
 	build() *sinkGroup
 }
@@ -239,6 +239,7 @@ func (sb *buildSinkGroup) buildLoaders(
 	tlsConfig *kafka.TLSConfig,
 	defaultMaxOpenConns int,
 	defaultMaxIdleConns int,
+	prometheusURL string,
 ) sinkGroupBuilder {
 	loaders := []Deployment{}
 	if sb.rsk.Spec.Loader.SinkGroup != nil {
@@ -301,6 +302,7 @@ func (sb *buildSinkGroup) buildLoaders(
 				tlsConfig,
 				defaultMaxOpenConns,
 				defaultMaxIdleConns,
+				prometheusURL,
 			)
 			if err != nil {
 				klog.Fatalf("Error making loader: %v", err)
@@ -326,6 +328,7 @@ func (sb *buildSinkGroup) buildLoaders(
 			tlsConfig,
 			defaultMaxOpenConns,
 			defaultMaxIdleConns,
+			prometheusURL,
 		)
 		if err != nil {
 			klog.Fatalf("Error making loader: %v", err)

--- a/redshiftsink/pkg/prometheus/prometheus.go
+++ b/redshiftsink/pkg/prometheus/prometheus.go
@@ -13,11 +13,13 @@ import (
 )
 
 type Client interface {
+	Address() string
 	Query(queryString string) (float64, error)
 }
 
 type promClient struct {
-	client prometheusv1.API
+	address string
+	client  prometheusv1.API
 
 	mutex sync.Mutex
 
@@ -37,6 +39,7 @@ func NewClient(address string) (Client, error) {
 	}
 
 	return &promClient{
+		address:            address,
 		client:             prometheusv1.NewAPI(client),
 		queryCache:         make(map[string]float64),
 		queryLastRun:       make(map[string]*int64),
@@ -82,6 +85,10 @@ func convertValueToFloat(val model.Value) float64 {
 		)
 		return 0
 	}
+}
+
+func (p *promClient) Address() string {
+	return p.address
 }
 
 func (p *promClient) Query(queryString string) (float64, error) {


### PR DESCRIPTION
- `allowRsks` flag to allow rsks
- When nothing done in reconcile dont reconcile for 15mins to keep the queue load minimum
- prometheus is central to all rsk