### PR TITLE
Reduce queries to redshift

### DIFF
--- a/redshiftsink/pkg/redshiftloader/load_processor.go
+++ b/redshiftsink/pkg/redshiftloader/load_processor.go
@@ -223,11 +223,6 @@ func (b *loadProcessor) loadTable(
 		tx.Rollback()
 		return fmt.Errorf("Error loading data in staging table, err:%v\n", err)
 	}
-	err = tx.Commit()
-	if err != nil {
-		return fmt.Errorf("Error committing tx, err:%v\n", err)
-	}
-
 	klog.V(2).Infof(
 		"%s, copied staging\n",
 		b.topic,


### PR DESCRIPTION
- [x] Use cache for targettable if schema was processed before. It is not required to construct always. Any manual change to Redshift is a problem after this.
- [x] Reduce double drop queries and make it use one.
- [x] Run Create staging and load in one tx.

Fixes #204 
would also make loads faster https://github.com/practo/tipoca-stream/issues/186