### PR TITLE
Throttling support for all redshift databases

### DIFF
--- a/REDSHIFTSINK.md
+++ b/REDSHIFTSINK.md
@@ -239,6 +239,7 @@ CREATE SCHEMA redshiftsink_operator;
 Please change the below two in the SQL below, before running it to create the view. View [source](https://github.com/awslabs/amazon-redshift-utils/blob/184c2ba7fd9d497027a831ca72e08fe09e79fd0b/src/AdminViews/v_get_tbl_scan_frequency.sql)
 1. `AND s.userid != 100` with the user id(s) of the redshiftsink user
 2. `AND s.starttime > GETDATE() - interval '3 day'` with the time window you want to consider a table is in use or not.
+3. Please create the following view for all the databases in Redshift you need. Then, add the list of these databases in the operator flag `--databases=`. This is required so that the operator queries the view for all the databases.
 
 ```sql
 CREATE OR REPLACE VIEW redshiftsink_operator.scan_query_total AS

--- a/cmd/redshiftsink/main.go
+++ b/cmd/redshiftsink/main.go
@@ -59,8 +59,8 @@ func parseDatabase(databases string) []*string {
 
 	if databases != "" {
 		supplied := strings.Split(databases, ",")
-		for _, db := range supplied {
-			dbs = append(dbs, &db) // use supplied dbs
+		for i, _ := range supplied {
+			dbs = append(dbs, &supplied[i]) // use supplied dbs
 		}
 	} else {
 		dbs = append(dbs, nil) // use default db from config

--- a/config/operator/redshiftsink_operator.yaml
+++ b/config/operator/redshiftsink_operator.yaml
@@ -51,6 +51,7 @@ spec:
        - --allowed-rsks=
        - --promethus-url=
        - --collect-redshift-metrics=false
+       - --databases=
        resources:
          limits:
            cpu: 300m

--- a/controllers/redshift_connection.go
+++ b/controllers/redshift_connection.go
@@ -11,6 +11,7 @@ func NewRedshiftConn(
 	client client.Client,
 	secretName,
 	secretNamespace string,
+	database *string,
 ) (
 	*redshift.Redshift,
 	error,
@@ -22,6 +23,9 @@ func NewRedshiftConn(
 	}
 	for key, value := range k8sSecret.Data {
 		secret[key] = string(value)
+	}
+	if database != nil {
+		secret["redshiftDatabase"] = *database
 	}
 
 	return NewRedshiftConnection(secret, "")


### PR DESCRIPTION
Currently redshift metrics are exported only for one database. Redshift system tables return response for only the database the connection is for. Since Redshift does not support cross db queries for System tables.

We are doing below:
1. The scan_query_total view would need to be created for all dbs.
2. The --databases needs to be passed to the operator.
3. The operator would run the fetch for query_total for all dbs then. Default is still to use the one database based on config.