### PR TITLE
Read also need synchronization

### DIFF
--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -117,7 +117,9 @@ func (p *promClient) queryWithRetry(
 
 func (p *promClient) Query(queryString string) (float64, error) {
 	// return from cache if cache hit
+	p.mutex.Lock()
 	lastRun, ok := p.queryLastRun[queryString]
+	p.mutex.Unlock()
 	if ok {
 		if cacheValid(p.queryCacheValidity, lastRun) {
 			cache, ok := p.queryCache[queryString]


### PR DESCRIPTION
"If there is at least one writer and at least one more either writer or reader, then all readers and writers must use synchronization to access the map. A mutex works fine for this"

https://stackoverflow.com/questions/11063473/map-with-concurrent-access

Fixes Fatal for the loaders:

Crash log:
```
fatal error: concurrent map read and map write
goroutine 4112 [running]:
runtime.throw(0x12247f0, 0x21)
        /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc000c87728 sp=0xc000c876f8 pc=0x438072
runtime.mapaccess2_faststr(0x1088500, 0xc000257e90, 0x121b92b, 0x1b, 0x3, 0x3)
        /usr/local/go/src/runtime/map_faststr.go:116 +0x4a5 fp=0xc000c87798 sp=0xc000c87728 pc=0x414265
github.com/practo/tipoca-stream/pkg/prometheus.(*promClient).Query(0xc000b0a5c0, 0x121b92b, 0x1b, 0x0, 0x0, 0x0)
        /src/pkg/prometheus/prometheus.go:120 +0x91 fp=0xc000c87870 sp=0xc000c87798 pc=0xf5bf51
```