### PR TITLE
Fixes panic for Intn() and the random maxWait bug

### DIFF
--- a/pkg/util/random.go
+++ b/pkg/util/random.go
@@ -26,7 +26,7 @@ func Randomize(
 	}
 
 	gap := max - min
-	if gap == 0 || gap < 0 {
+	if gap <= 0 {
 		return min
 	}
 

--- a/pkg/util/random.go
+++ b/pkg/util/random.go
@@ -25,5 +25,10 @@ func Randomize(
 		min = value - diff
 	}
 
-	return min + rand.Intn(max-min)
+	gap := max - min
+	if gap == 0 || gap < 0 {
+		return min
+	}
+
+	return min + rand.Intn(gap)
 }

--- a/pkg/util/random_test.go
+++ b/pkg/util/random_test.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ func TestRandomize(t *testing.T) {
 
 	maxAllowed := 1800
 	minAllowed := 1800
+	max4 := 4
 
 	tests := []struct {
 		name        string
@@ -50,13 +50,21 @@ func TestRandomize(t *testing.T) {
 			maxAllowed:  nil,
 			minAllowed:  &minAllowed,
 		},
+		{
+			name:        "with max-min ==0",
+			value:       4,
+			diffPercent: 0.2,
+			maxAllowed:  &max4,
+			minAllowed:  nil,
+			min:         4,
+			max:         4,
+		},
 	}
 
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			v := Randomize(tc.value, tc.diffPercent, tc.maxAllowed, tc.minAllowed)
-			fmt.Println(v)
 			if v < tc.min || v > tc.max {
 				t.Errorf("expected in range: >%v <%v, got: %v\n", tc.min, tc.max, v)
 			}


### PR DESCRIPTION
- Fix panic when bad input passed to the randomizer `"panic: invalid argument to Intn"`
- Fix the bug on maxWait decrementing on every restart by using a local copy to prevent bad input.