### PR TITLE
Upgrade Producer 

### DIFF
--- a/build/producer/connect-debezium/0.19.0-kakfa-2.5.0-mysqlconnector-1.3.0-avro-5.5.0/README.md
+++ b/build/producer/connect-debezium/0.19.0-kakfa-2.5.0-mysqlconnector-1.3.0-avro-5.5.0/README.md
@@ -1,37 +1,37 @@
 ## Downloading the connector binary
 ```
-curl https://repo1.maven.org/maven3/io/debezium/debezium-connector-mysql/1.3.0.Final/debezium-connector-mysql-1.3.0.Final-plugin.tar.gz | tar xvz
+curl https://repo1.maven.org/maven3/io/debezium/debezium-connector-mysql/1.8.0.Final/debezium-connector-mysql-1.8.0.Final-plugin.tar.gz | tar xvz
 ```
 Note: You might need to download from browser.
 
 More Info: https://strimzi.io/blog/2020/01/27/deploying-debezium-with-kafkaconnector-resource/
-More Info: Debezium Docker images https://github.com/debezium/docker-images/tree/master/connect/1.2
-AVRO JARS: https://github.com/debezium/docker-images/blob/master/connect-base/1.2/Dockerfile
+More Info: Debezium Docker images https://github.com/debezium/docker-images/tree/master/connect/1.8
+AVRO JARS: https://github.com/debezium/docker-images/blob/master/connect-base/1.8/Dockerfile
 
 ### Helpful script for downloading binary
 `./docker-maven-dowload.sh`
 
 ```
 export MAVEN_DEP_DESTINATION="."
-export CONFLUENT_VERSION=5.5.0
+export CONFLUENT_VERSION=6.0.2
 export AVRO_VERSION=1.9.2
 export AVRO_JACKSON_VERSION=1.9.13
-export APICURIO_VERSION=1.2.2.Final
-./docker-maven-download.sh confluent kafka-connect-avro-converter "$CONFLUENT_VERSION" 16c38a7378032f850f0293b7654aa6bf && \
-./docker-maven-download.sh confluent kafka-connect-avro-data "$CONFLUENT_VERSION" 63022db9533689968540f45be705786d && \
-./docker-maven-download.sh confluent kafka-avro-serializer "$CONFLUENT_VERSION" b1379606e1dcc5d7b809c82abe294cc7 && \
-./docker-maven-download.sh confluent kafka-schema-serializer "$CONFLUENT_VERSION" b68a7eebf7ce6a1b826bd5bbb443b176 && \
-./docker-maven-download.sh confluent kafka-schema-registry-client "$CONFLUENT_VERSION" e3631a8a3fe10312a727e9d50fcd5527 && \
-./docker-maven-download.sh confluent common-config "$CONFLUENT_VERSION" e1a4dc2b6d1d8d8c2df47db580276f38 && \
-./docker-maven-download.sh confluent common-utils "$CONFLUENT_VERSION" ad9e39d87c6a9fa1a9b19e6ce80392fa && \
-./docker-maven-download.sh central org/codehaus/jackson jackson-core-asl "$AVRO_JACKSON_VERSION" 319c49a4304e3fa9fe3cd8dcfc009d37 && \
-./docker-maven-download.sh central org/codehaus/jackson jackson-mapper-asl "$AVRO_JACKSON_VERSION" 1750f9c339352fc4b728d61b57171613 && \
-./docker-maven-download.sh central org/apache/avro avro "$AVRO_VERSION" cb70195f70f52b27070f9359b77690bb
+export APICURIO_VERSION=2.0.2.Final
+./docker-maven-download.sh confluent kafka-connect-avro-converter "$CONFLUENT_VERSION" 4671dec77c8af4689e20419538e7b915 && \
+./docker-maven-download.sh confluent kafka-connect-avro-data "$CONFLUENT_VERSION" 5dc1111ccc4dc9c57397a2c298e6a221 && \
+./docker-maven-download.sh confluent kafka-avro-serializer "$CONFLUENT_VERSION" 5bb0c8078919e5aed55e9b59323a661e && \
+./docker-maven-download.sh confluent kafka-schema-serializer "$CONFLUENT_VERSION" 907f384780d9b75e670e6a5f4f522873 && \
+./docker-maven-download.sh confluent kafka-schema-registry-client "$CONFLUENT_VERSION" 727ef72bcc04c7a8dbf2439edf74ed38 && \
+./docker-maven-download.sh confluent common-config "$CONFLUENT_VERSION" 0cfba1fc7203305ed25bd67b29b6f094 && \
+./docker-maven-download.sh confluent common-utils "$CONFLUENT_VERSION" a940fcd0449613f956127f16cdea9935 && \
+./docker-maven-download.sh central org/codehaus/jackson jackson-core-asl $AVRO_JACKSON_VERSION 319c49a4304e3fa9fe3cd8dcfc009d37&& \
+./docker-maven-download.sh central org/codehaus/jackson jackson-mapper-asl $AVRO_JACKSON_VERSION 1750f9c339352fc4b728d61b57171613 && \
+./docker-maven-download.sh central org/apache/avro avro "$AVRO_VERSION" cb70195f70f52b27070f9359b77690bb 
 ```
 
 ## Instructions to build the image
 ```
 export DOCKER_ORG=practodev
-docker build . -t ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
-docker push ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
+docker build . -t ${DOCKER_ORG}/connect-debezium:0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-6.0.2
+docker push ${DOCKER_ORG}/connect-debezium:0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-6.0.2
 ```

--- a/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/.gitignore
+++ b/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/.gitignore
@@ -1,0 +1,4 @@
+debezium-connector-mysql
+debezium-connector-mysql-1.2.1.Final-plugin.tar.gz
+kafka-connect-avro-converter-5.5.0.jar
+*.jar

--- a/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/Dockerfile
+++ b/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/Dockerfile
@@ -1,0 +1,18 @@
+FROM strimzi/kafka:0.19.0-kafka-2.5.0
+USER root:root
+RUN mkdir -p /opt/kafka/plugins/debezium
+COPY docker-maven-download.sh /usr/local/bin/docker-maven-download
+
+COPY ./debezium-connector-mysql/ /opt/kafka/plugins/debezium/
+
+COPY ./kafka-connect-avro-converter-5.5.0.jar /opt/kafka/libs/
+COPY ./kafka-connect-avro-data-5.5.0.jar /opt/kafka/libs/
+COPY ./kafka-avro-serializer-5.5.0.jar /opt/kafka/libs/
+COPY ./kafka-schema-serializer-5.5.0.jar /opt/kafka/libs/
+COPY ./kafka-schema-registry-client-5.5.0.jar /opt/kafka/libs/
+COPY ./avro-1.9.2.jar /opt/kafka/libs/
+COPY ./common-config-5.5.0.jar /opt/kafka/libs/
+COPY ./common-utils-5.5.0.jar /opt/kafka/libs/
+COPY ./jackson-core-asl-1.9.13.jar /opt/kafka/libs/
+COPY ./jackson-mapper-asl-1.9.13.jar /opt/kafka/libs/
+USER 1001

--- a/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/README.md
+++ b/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/README.md
@@ -1,0 +1,37 @@
+## Downloading the connector binary
+```
+curl https://repo1.maven.org/maven3/io/debezium/debezium-connector-mysql/1.3.0.Final/debezium-connector-mysql-1.3.0.Final-plugin.tar.gz | tar xvz
+```
+Note: You might need to download from browser.
+
+More Info: https://strimzi.io/blog/2020/01/27/deploying-debezium-with-kafkaconnector-resource/
+More Info: Debezium Docker images https://github.com/debezium/docker-images/tree/master/connect/1.8
+AVRO JARS: https://github.com/debezium/docker-images/blob/master/connect-base/1.8/Dockerfile
+
+### Helpful script for downloading binary
+`./docker-maven-dowload.sh`
+
+```
+export MAVEN_DEP_DESTINATION="."
+export CONFLUENT_VERSION=5.5.0
+export AVRO_VERSION=1.9.2
+export AVRO_JACKSON_VERSION=1.9.13
+export APICURIO_VERSION=1.2.2.Final
+./docker-maven-download.sh confluent kafka-connect-avro-converter "$CONFLUENT_VERSION" 16c38a7378032f850f0293b7654aa6bf && \
+./docker-maven-download.sh confluent kafka-connect-avro-data "$CONFLUENT_VERSION" 63022db9533689968540f45be705786d && \
+./docker-maven-download.sh confluent kafka-avro-serializer "$CONFLUENT_VERSION" b1379606e1dcc5d7b809c82abe294cc7 && \
+./docker-maven-download.sh confluent kafka-schema-serializer "$CONFLUENT_VERSION" b68a7eebf7ce6a1b826bd5bbb443b176 && \
+./docker-maven-download.sh confluent kafka-schema-registry-client "$CONFLUENT_VERSION" e3631a8a3fe10312a727e9d50fcd5527 && \
+./docker-maven-download.sh confluent common-config "$CONFLUENT_VERSION" e1a4dc2b6d1d8d8c2df47db580276f38 && \
+./docker-maven-download.sh confluent common-utils "$CONFLUENT_VERSION" ad9e39d87c6a9fa1a9b19e6ce80392fa && \
+./docker-maven-download.sh central org/codehaus/jackson jackson-core-asl "$AVRO_JACKSON_VERSION" 319c49a4304e3fa9fe3cd8dcfc009d37 && \
+./docker-maven-download.sh central org/codehaus/jackson jackson-mapper-asl "$AVRO_JACKSON_VERSION" 1750f9c339352fc4b728d61b57171613 && \
+./docker-maven-download.sh central org/apache/avro avro "$AVRO_VERSION" cb70195f70f52b27070f9359b77690bb
+```
+
+## Instructions to build the image
+```
+export DOCKER_ORG=practodev
+docker build . -t ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
+docker push ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
+```

--- a/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/docker-maven-download.sh
+++ b/build/producer/connect-debezium/0.27.0-kakfa-3.0.0-mysqlconnector-1.8.0-avro-7.0.1/docker-maven-download.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+set +x
+
+#
+# Download connector maven dependencies
+# 4 methods are available:
+# - maven_dep(REPO, GROUP, PACKAGE, VERSION, FILE, MD5_CHECKSUM) # Downloads anything from a maven repo
+# - maven_core_dep(GROUP, PACKAGE, VERSION, MD5_CHECKSUM) # Downloads jar files
+# - maven_confluent_dep(GROUP, PACKAGE, VERSION, MD5_CHECKSUM) # Downloads jar files for Confluent deps
+# - maven_debezium_plugin(CONNECTOR, VERSION, MD5_CHECKSUM) # Downnloads debezium tar plugin
+#
+# Author: Renato Mefi <https://github.com/renatomefi>
+#
+set -e
+
+# If there's not maven repository url set externally,
+# default to the ones below
+MAVEN_REPO_CENTRAL=${MAVEN_REPO_CENTRAL:-"https://repo1.maven.org/maven2"}
+MAVEN_REPO_INCUBATOR=${MAVEN_REPO_INCUBATOR:-"https://repo1.maven.org/maven2"}
+MAVEN_REPO_CONFLUENT=${MAVEN_REPO_CONFLUENT:-"https://packages.confluent.io/maven"}
+MAVEN_DEP_DESTINATION=${MAVEN_DEP_DESTINATION}
+EXTERNAL_LIBS_DIR=${EXTERNAL_LIBS_DIR}
+
+maven_dep() {
+    local REPO="$1"
+    local GROUP="$2"
+    local PACKAGE="$3"
+    local VERSION="$4"
+    local FILE="$5"
+    local MD5_CHECKSUM="$6"
+
+    DOWNLOAD_FILE_TMP_PATH="/tmp/maven_dep/${PACKAGE}"
+    DOWNLOAD_FILE="$DOWNLOAD_FILE_TMP_PATH/$FILE"
+    test -d $DOWNLOAD_FILE_TMP_PATH || mkdir -p $DOWNLOAD_FILE_TMP_PATH
+
+    curl -sfSL -o "$DOWNLOAD_FILE" "$REPO/$GROUP/$PACKAGE/$VERSION/$FILE"
+
+    echo "$MD5_CHECKSUM  $DOWNLOAD_FILE" | md5sum -c -
+}
+
+maven_central_dep() {
+    maven_dep $MAVEN_REPO_CENTRAL $1 $2 $3 "$2-$3.jar" $4
+    mv "$DOWNLOAD_FILE" $MAVEN_DEP_DESTINATION
+}
+
+maven_confluent_dep() {
+    maven_dep $MAVEN_REPO_CONFLUENT "io/confluent" $1 $2 "$1-$2.jar" $3
+    echo mv "$DOWNLOAD_FILE" $MAVEN_DEP_DESTINATION
+    mv "$DOWNLOAD_FILE" $MAVEN_DEP_DESTINATION
+}
+
+maven_debezium_plugin() {
+    maven_dep $MAVEN_REPO_CENTRAL "io/debezium" "debezium-connector-$1" $2 "debezium-connector-$1-$2-plugin.tar.gz" $3
+    tar -xzf "$DOWNLOAD_FILE" -C "$MAVEN_DEP_DESTINATION" && rm "$DOWNLOAD_FILE"
+}
+
+maven_debezium_incubator_plugin() {
+    maven_dep $MAVEN_REPO_INCUBATOR "io/debezium" "debezium-connector-$1" $2 "debezium-connector-$1-$2-plugin.tar.gz" $3
+    tar -xzf "$DOWNLOAD_FILE" -C "$MAVEN_DEP_DESTINATION" && rm "$DOWNLOAD_FILE"
+}
+
+maven_apicurio_converter() {
+    if [[ -z "$EXTERNAL_LIBS_DIR" ]] ; then
+        echo "WARNING: EXTERNAL_LIBS_DIR is not set. Skipping Apicurio converter loading..."
+        return
+    fi
+    if [[ ! -d "$EXTERNAL_LIBS_DIR" ]] ; then
+        echo "WARNING: EXTERNAL_LIBS_DIR is not a directory. Skipping Apicurio converter loading..."
+        return
+    fi
+    APICURIO_CONVERTER_PACKAGE="apicurio-registry-distro-connect-converter"
+    maven_dep $MAVEN_REPO_CENTRAL "io/apicurio" "$APICURIO_CONVERTER_PACKAGE" "$1" "$APICURIO_CONVERTER_PACKAGE-$1-converter.tar.gz" "$2"
+    mkdir "$EXTERNAL_LIBS_DIR/apicurio"
+    tar -xzf "$DOWNLOAD_FILE" -C "$EXTERNAL_LIBS_DIR/apicurio" && rm "$DOWNLOAD_FILE"
+}
+
+case $1 in
+    "central" ) shift
+            maven_central_dep ${@}
+            ;;
+    "confluent" ) shift
+            maven_confluent_dep ${@}
+            ;;
+    "debezium" ) shift
+            maven_debezium_plugin ${@}
+            ;;
+    "debezium-incubator" ) shift
+            maven_debezium_incubator_plugin ${@}
+            ;;
+    "apicurio" ) shift
+            maven_apicurio_converter ${@}
+            ;;
+esac


### PR DESCRIPTION
Central depedencies: https://github.com/debezium/docker-images/blob/v1.8.0.Final/connect-base/0.6/Dockerfile
Confluent dependencies: https://github.com/debezium/docker-images/blob/v1.8.0.Final/connect-base/1.8/Dockerfile

Debezium: 1.8.0
Strimzi: 0.27.0
Kafka: 3.0.0

PS: Tipoca Stream only keeps the Dockerfiles to build the producer image.
