### PR TITLE
Remove Dockerhub and use only Public ECR

### DIFF
--- a/build/inventory-mysql/inventory-mysql.yaml
+++ b/build/inventory-mysql/inventory-mysql.yaml
@@ -32,7 +32,7 @@ spec:
           value: mysqluser
         - name: MYSQL_PASSWORD
           value: mysqlpw
-        image: practodev/example-mysql:1.4
+        image: public.ecr.aws/practo/example-mysql:1.4
         imagePullPolicy: IfNotPresent
         name: mysql
         ports:

--- a/build/producer/connect-debezium/0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0/README.md
+++ b/build/producer/connect-debezium/0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0/README.md
@@ -31,7 +31,7 @@ export APICURIO_VERSION=1.2.2.Final
 
 ## Instructions to build the image
 ```
-export DOCKER_ORG=practodev
+export DOCKER_ORG=public.ecr.aws/practo
 docker build . -t ${DOCKER_ORG}/connect-debezium:0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
 docker push ${DOCKER_ORG}/connect-debezium:0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
 ```

--- a/build/producer/connect-debezium/0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1/README.md
+++ b/build/producer/connect-debezium/0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1/README.md
@@ -12,7 +12,7 @@ More Info: Debezium Docker images https://github.com/debezium/docker-images/tree
 
 ## Instructions to build the image
 ```
-export DOCKER_ORG=practodev
+export DOCKER_ORG=public.ecr.aws/practo
 docker build . -t ${DOCKER_ORG}/connect-debezium:0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1
 docker push ${DOCKER_ORG}/connect-debezium:0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1
 ```

--- a/build/producer/connect-debezium/0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0/README.md
+++ b/build/producer/connect-debezium/0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0/README.md
@@ -31,7 +31,7 @@ export APICURIO_VERSION=1.2.2.Final
 
 ## Instructions to build the image
 ```
-export DOCKER_ORG=practodev
+export DOCKER_ORG=public.ecr.aws/practo
 docker build . -t ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
 docker push ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
 ```

--- a/build/producer/connect-debezium/0.19.0-kakfa-2.5.0-mysqlconnector-1.3.0-avro-5.5.0/README.md
+++ b/build/producer/connect-debezium/0.19.0-kakfa-2.5.0-mysqlconnector-1.3.0-avro-5.5.0/README.md
@@ -31,7 +31,7 @@ export APICURIO_VERSION=1.2.2.Final
 
 ## Instructions to build the image
 ```
-export DOCKER_ORG=practodev
+export DOCKER_ORG=public.ecr.aws/practo
 docker build . -t ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
 docker push ${DOCKER_ORG}/connect-debezium:0.19.0-kakfa-2.5.0-mysqlconnector-1.2.1-avro-5.5.0
 ```

--- a/build/producer/examples/my-connect-cluster.yaml
+++ b/build/producer/examples/my-connect-cluster.yaml
@@ -8,7 +8,7 @@ metadata:
   # needing to call the Connect REST API directly
     strimzi.io/use-connector-resources: "true"
 spec:
-  image: practodev/connect-debezium:0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1
+  image: public.ecr.aws/practo/connect-debezium:0.18.0-kakfa-2.5.0-mysqlconnector-1.2.1
   replicas: 1
   bootstrapServers: k8s-kafka-bootstrap.kafka:9092
   config:


### PR DESCRIPTION
As we are removing practodev organization from Dockerhub, removing all references and usage. Only AWS Public ECR is to be used going forward.